### PR TITLE
Run autorelease every 3 months

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -3,7 +3,7 @@ name: Automatic releases
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 3 * * 0'
+    - cron: '10 10 * */3 0'
 
 jobs:
   auto-release:


### PR DESCRIPTION
It seems running autorelease every week is too often. Changes are not very significant. So switching into min 3 months interval.